### PR TITLE
Refactor and improve the caching logic and add logic to compute the function signature from a function definition AST node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/Struct.sol
+++ b/examples/Struct.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0;
+
+import "./interface.sol";
+
+struct A {
+    uint A_a; 
+    bool A_b;  
+    address A_c; 
+    uint A_d;   
+}
+
+
+contract Contract1 is SInterface {
+
+    struct B {
+        bytes32 B_a;  
+        uint B_b;
+        address B_c; 
+        X B_X;     
+    }
+
+    function f(A calldata a, B calldata b) pure public returns (X memory){
+        X memory xx = X(a.A_a,b.B_b);
+        return xx; 
+    }
+}
+
+contract Contract2 is Contract1 {
+
+    function f_2(X calldata xx, Party memory party) pure public returns (bool){
+        return false; 
+    }
+}

--- a/examples/interface.sol
+++ b/examples/interface.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0;
+
+struct Party {
+  address wallet; 
+  address token; 
+  uint256 id; 
+  uint256 amount; 
+}
+
+interface SInterface {
+    struct X {
+        uint X_a;
+        uint X_b; 
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solidity-workspace",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solidity-workspace",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@solidity-parser/parser": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity-workspace",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Turn solidity source code into AST objects with easy access to contracts, functions, ...",
   "keywords": [
     "solidity",

--- a/src/helper/funcSig.js
+++ b/src/helper/funcSig.js
@@ -1,9 +1,9 @@
 'use strict';
-/** 
+/**
  * @author github.com/tintinweb
  * @author github.com/vquelque
  * @license MIT
- * 
+ *
  * */
 
 // https://github.com/ethereum/eth-abi/blob/b02fc85b01a9674add88483b0d6144029c09e0a0/eth_abi/grammar.py#L402-L408
@@ -32,14 +32,15 @@ function getCanonicalizedArgumentFromAstNode(
   _parent,
   contract,
   array = false,
-  isStruct = false
+  isInsideStruct = false
 ) {
   if (!array && !node.typeName) {
-    console.log(node);
+
     throw new Error('Failed to unpack function argument type');
   }
   const argStorageLocation = node.storageLocation;
   const argTypeNode = !array ? node.typeName : node;
+  const sourceUnit = contract._parent;
   switch (argTypeNode.type) {
     case 'ElementaryTypeName':
       return argTypeNode.name;
@@ -49,35 +50,42 @@ function getCanonicalizedArgumentFromAstNode(
           argTypeNode.baseTypeName,
           _parent,
           contract,
-          true
+          true,
+          isInsideStruct
         ) + '[]';
       return repr;
     case 'UserDefinedTypeName':
-      if (!argStorageLocation && !isStruct) {
+      const isEnum =
+        contract.enums[argTypeNode.namePath] ||
+        contract.enums[argTypeNode.namePath] ||
+        sourceUnit.enums[argTypeNode.namePath];
+      if (isEnum) {
+        return 'uint8';
+      }
+      if (!argStorageLocation && !isInsideStruct && !array) {
         return 'address';
       }
-      const sourceUnit = contract._parent;
       const struct =
         contract.structs[argTypeNode.namePath] ||
         contract.inherited_structs[argTypeNode.namePath] ||
         sourceUnit.structs[argTypeNode.namePath];
       if (!struct) {
+        console.log(node);
         throw new Error(
           `Failed to resolve struct ${node.namePath} in current scope.`
         );
       }
       const structTypes = struct.members.map((m) =>
-        getCanonicalizedArgumentFromAstNode(m, _parent,contract, false, true)
+        getCanonicalizedArgumentFromAstNode(m, _parent, contract, false, true)
       );
       const structSig = '(' + structTypes.join(',') + ')';
       return structSig;
     default:
-      console.log(argTypeNode);
       throw new Error('wrong argument type: ' + argTypeNode.name);
   }
 }
 
 module.exports = {
   getCanonicalizedArgumentFromAstNode,
-  canonicalizeEvmType
+  canonicalizeEvmType,
 };

--- a/src/helper/funcSig.js
+++ b/src/helper/funcSig.js
@@ -1,0 +1,83 @@
+'use strict';
+/** 
+ * @author github.com/tintinweb
+ * @author github.com/vquelque
+ * @license MIT
+ * 
+ * */
+
+// https://github.com/ethereum/eth-abi/blob/b02fc85b01a9674add88483b0d6144029c09e0a0/eth_abi/grammar.py#L402-L408
+const TYPE_ALIASES = {
+  int: 'int256',
+  uint: 'uint256',
+  fixed: 'fixed128x18',
+  ufixed: 'ufixed128x18',
+  function: 'bytes24',
+};
+const evmTypeRegex = new RegExp(
+  `(?<type>(${Object.keys(TYPE_ALIASES).join('|')}))(?<tail>(\\[[^\\]]*\\])?)$`,
+  'g'
+);
+
+function canonicalizeEvmType(evmArg) {
+  function replacer(...groups) {
+    const foundings = groups.pop();
+    return `${TYPE_ALIASES[foundings.type]}${foundings.tail}`;
+  }
+  return evmArg.replace(evmTypeRegex, replacer);
+}
+
+function getCanonicalizedArgumentFromAstNode(
+  node,
+  _parent,
+  contract,
+  array = false,
+  isStruct = false
+) {
+  if (!array && !node.typeName) {
+    console.log(node);
+    throw new Error('Failed to unpack function argument type');
+  }
+  const argStorageLocation = node.storageLocation;
+  const argTypeNode = !array ? node.typeName : node;
+  switch (argTypeNode.type) {
+    case 'ElementaryTypeName':
+      return argTypeNode.name;
+    case 'ArrayTypeName':
+      const repr =
+        getCanonicalizedArgumentFromAstNode(
+          argTypeNode.baseTypeName,
+          _parent,
+          contract,
+          true
+        ) + '[]';
+      return repr;
+    case 'UserDefinedTypeName':
+      if (!argStorageLocation && !isStruct) {
+        return 'address';
+      }
+      const sourceUnit = contract._parent;
+      const struct =
+        contract.structs[argTypeNode.namePath] ||
+        contract.inherited_structs[argTypeNode.namePath] ||
+        sourceUnit.structs[argTypeNode.namePath];
+      if (!struct) {
+        throw new Error(
+          `Failed to resolve struct ${node.namePath} in current scope.`
+        );
+      }
+      const structTypes = struct.members.map((m) =>
+        getCanonicalizedArgumentFromAstNode(m, _parent,contract, false, true)
+      );
+      const structSig = '(' + structTypes.join(',') + ')';
+      return structSig;
+    default:
+      console.log(argTypeNode);
+      throw new Error('wrong argument type: ' + argTypeNode.name);
+  }
+}
+
+module.exports = {
+  getCanonicalizedArgumentFromAstNode,
+  canonicalizeEvmType
+};

--- a/src/helper/lru.js
+++ b/src/helper/lru.js
@@ -1,0 +1,39 @@
+'use strict';
+/** 
+ * @author github.com/vquelque
+ * @license MIT
+ * 
+ * This class implements a cache with an LRU policy
+ * */
+class LRU {
+    constructor(max = 1000) {
+        this.max = max;
+        this.cache = new Map();
+    }
+
+    get(key) {
+        let item = this.cache.get(key);
+        if (item) {
+            // refresh key - O(1)
+            this.cache.delete(key);
+            this.cache.set(key, item);
+        }
+        return item;
+    }
+
+    set(key, val) {
+        // refresh key 
+        if (this.cache.has(key)) this.cache.delete(key);
+        // evict least recently used
+        else if (this.cache.size == this.max) this.cache.delete(this.first());
+        this.cache.set(key, val);
+    }
+
+    first() {
+        return this.cache.keys().next().value;
+    }
+}
+
+module.exports = {
+    LRU
+};

--- a/src/helper/promise.js
+++ b/src/helper/promise.js
@@ -1,0 +1,24 @@
+'use strict';
+/** 
+ * @author github.com/tintinweb
+ * @author github.com/vquelque
+ * @license MIT
+ * 
+ * */
+
+
+//this wraps a Promise and rejects if it has not settled after "millis" ms 
+const withTimeout = (millis, promise) => {
+    const timeout = new Promise((resolve, reject) =>
+        setTimeout(
+            () => reject(`Promise timed out after ${millis} ms.`),
+            millis));
+    return Promise.race([
+        promise,
+        timeout
+    ]);
+};
+
+module.exports = {
+    withTimeout
+}

--- a/src/parser/solidity.js
+++ b/src/parser/solidity.js
@@ -1,79 +1,97 @@
 'use strict';
-/** 
+/**
  * @author github.com/tintinweb
  * @license MIT
- * 
+ *
  * */
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const createKeccakHash = require('keccak');
+const {
+  canonicalizeEvmType,
+  getCanonicalizedArgumentFromAstNode,
+} = require('../helper/funcSig');
 
 const { linearize } = require('c3-linearization');
 const parser = require('@solidity-parser/parser');
 
-const { parserHelpers } = require("./parserHelpers");
-const { ParserError, CacheHit } = require("./exceptions");
+const { parserHelpers } = require('./parserHelpers');
+const { ParserError, CacheHit } = require('./exceptions');
+const { LRU } = require('../helper/lru');
+const { withTimeout } = require('../helper/promise');
 
+const PARSER_TIMEOUT = 3000; //bail after 3 secs.
 
 function getExpressionIdentifier(node) {
-    while (node.expression) {
-        node = node.expression;
-        if (node.type == "Identifier") {
-            return node;
-        }
+  while (node.expression) {
+    node = node.expression;
+    if (node.type == 'Identifier') {
+      return node;
     }
+  }
 }
 
 class Workspace {
-    constructor(basedirs, options) {
-        this.basedirs = basedirs || [];
-        this.options = options || { parseImports: true, resolveIdentifiers: true, resolveInheritedStructs: true }; 
-        this.sourceUnits = {};  // path -> sourceUnit
-        this.sourceUnitsCache = {}; // hash -> sourceUnit
-        this.lastParsedSourceUnit = {}; //path -> lastSourceUnitParsed
-        this.sourceUnitNametoSourceUnit = {}
+  constructor(basedirs, options) {
+    this.basedirs = basedirs || [];
+    this.options = options || {
+      parseImports: true,
+      resolveIdentifiers: true,
+      resolveInheritance: true,
+    };
+    this.sourceUnits = {}; // su path -> sourceUnit
+    this.sourceUnitNametoSourceUnit = {}; //su filename --> sourceUnit
+    this.sourceUnitsCache = new LRU(500); // LRU hash -> sourceUnit.
 
-        this._runningTasks = [];
+    this._runningTasks = [];
+  }
+
+  async add(fpath, options) {
+    // options = {skipExistingPath, content}
+    options = options || {};
+    fpath = path.resolve(fpath); //always use abspath
+    if (!fpath) return
+    // check if there's a running task for that source unit already
+    let maybeTasks = this._runningTasks.find((t) => t.meta === fpath);
+    if (maybeTasks) {
+      return maybeTasks.promise; // skip adding another job for this file
     }
 
-    async add(fpath, options) { // options = {skipExistingPath, content}
-        options = options || {};
-        fpath = path.resolve(fpath); //always use abspath
+    const promise = new Promise(async (resolve, reject) => {
+      var sourceUnit;
+      let cacheHit;
 
-        // check if there's a running task for that source unit already
-        let maybeTasks = this._runningTasks.find(t => t.meta === fpath);
-        if (maybeTasks) {
-            return maybeTasks.promise; // skip adding another job for this file
+      // avoid parsing files multiple times when subparsing imports; normally not used. lib will automatically return cached sourceUnits if available (see CacheHit)
+      const inCache = this.sourceUnits[fpath]
+      if (options.skipExistingPath && inCache) {
+        return resolve(inCache);
+      }
+      try {
+        // good path; "fromSource()" will auto. check. internal cache to avoid parsing the same file multiple times
+        sourceUnit = new SourceUnit(this);
+        if (options.content) {
+          // take content instead of reading it from file
+          sourceUnit.fromSource(options.content);
+          sourceUnit.filePath = fpath;
+        } else {
+          sourceUnit = sourceUnit.fromFile(fpath); //options.imports
         }
-
-        let promise = new Promise(async (resolve, reject) => {
-            var sourceUnit;
-            let cacheHit;
-
-            // avoid parsing files multiple times when subparsing imports; normally not used. lib will automatically return cached sourceUnits if available (see CacheHit)
-            if (options.skipExistingPath && this.sourceUnits[fpath]) {
-                return resolve(this.sourceUnits[fpath]);
-            }
-
-            try {
-                // good path; "fromSource()" will auto. check. internal cache to avoid parsing the same file multiple times
-                sourceUnit = new SourceUnit(this);
-                if (options.content) { // take content instead of reading it from file
-                    sourceUnit.fromSource(options.content);
-                    sourceUnit.filePath = fpath;
-                } else {
-                    sourceUnit = sourceUnit.fromFile(fpath); //options.imports
-                }
-                this.sourceUnitsCache[sourceUnit.hash] = sourceUnit;
-
-            } catch (e) {
-                if (e instanceof CacheHit) {
-                    // duplicate source unit (or dbl parse)
-                    // 
-                    sourceUnit = e.sourceUnit.clone(); //clone the object, override the path
-                    sourceUnit.filePath = fpath;
-                    cacheHit = true;
-                    /*
+      } catch (e) {
+        if (e instanceof CacheHit) {
+          // duplicate source unit (or dbl parse)
+          console.log('cache hit')
+          cacheHit = true
+          if (fpath && e.sourceUnit.filePath !== fpath) {
+            //same source unit hash, but other path
+            console.log('same source unit, other fpath')
+            sourceUnit = e.sourceUnit.clone(); //clone the object, override the path
+            sourceUnit.filePath = fpath;
+          } else {
+            //same hash, same path
+            sourceUnit = e.sourceUnit
+          }
+          /*
                     } else if (e instanceof parser.ParserError) {
                         //unable to parse
                         console.error(e);
@@ -83,1100 +101,1309 @@ class Workspace {
                         //unable to parse; parser error
                         console.error(e);
                     */
-                } else {
-                    return reject(e);
-                }
-            }
-            this.sourceUnits[fpath] = sourceUnit;
-            this.sourceUnitNametoSourceUnit[path.basename(fpath)] = sourceUnit;
-
-            if (!cacheHit && this.options.parseImports) { //avoid parsing imports for cacheHits
-                try {
-                    await sourceUnit._fsFindImports().forEach(importPath => this.add(importPath, { skipExistingPath: true }).catch(e => { console.error(importPath); console.error(e) })); // avoid race when parsing the same imports
-                } catch (e) {
-                    console.error(e);
-                }
-            }
-
-            return resolve(sourceUnit);
-        });
-        this._runningTasks.push({ meta: fpath, promise });
-        return promise;
-    }
-
-    async withParserReady() {
-        let hardStop = Date.now() + 5 * 1000; // exit loop if stuck for more than 5 seconds
-        let finishedPromises = []
-
-        while (this._runningTasks.length !== 0 && Date.now() < hardStop) {
-            let selectedTasks = this._runningTasks;
-
-            let values = await Promise.allSettled(selectedTasks.map(t => t.promise));
-            if (values.length === 0) {
-                break;
-            }
-            finishedPromises = finishedPromises.concat(values);
-            this._runningTasks = this._runningTasks.filter(t => !selectedTasks.includes(t))
+        } else {
+          return reject(e);
         }
-        if (finishedPromises.length === 0) {
-            return finishedPromises;
+      }
+
+      this.sourceUnitsCache.set(sourceUnit.hash, sourceUnit);
+      this.sourceUnits[fpath] = sourceUnit;
+      this.sourceUnitNametoSourceUnit[path.basename(fpath)] = sourceUnit;
+
+      if (!cacheHit && this.options.parseImports) {
+        //avoid parsing imports for cacheHits
+        try {
+          await sourceUnit._fsFindImports().forEach((importPath) =>
+            this.add(importPath, { skipExistingPath: true }).catch((e) => {
+              console.error(importPath);
+              console.error(e);
+            })
+          ); // avoid race when parsing the same imports
+        } catch (e) {
+          console.error(e);
         }
-        this.update();
-        return finishedPromises;
+      }
+
+      return resolve(sourceUnit);
+    });
+    this._runningTasks.push({
+      meta: fpath,
+      promise: withTimeout(PARSER_TIMEOUT, promise),
+    }); //break if promise not resolved after 3sec
+    return promise;
+  }
+
+  //this resolves when all sourceUnits in scope have been parsed, and inherited identifiers from dependencies resolved.
+  async withParserReady(currentSourceUnit, resolveAllInheritance) {
+    const values = await Promise.allSettled(
+      this._runningTasks.map((t) => t.promise)
+    );
+
+    const finishedPromises = values.filter(
+      (value) => value.status === 'fulfilled'
+    );
+
+    this._runningTasks = [];
+
+    this.update(currentSourceUnit, resolveAllInheritance);
+    return finishedPromises;
+  }
+
+  update(currentSourceUnit, resolveAllInheritance) {
+    this._resolveDepsAndPropagateInheritedNames(
+      currentSourceUnit,
+      resolveAllInheritance
+    );
+    this._resolveExternalCalls2ndPass();
+  }
+
+  /** GETTER */
+  get(key) {
+    return this.sourceUnits[key];
+  }
+
+  async getSourceUnitByPath(path) {
+    const su = this.sourceUnits[path];
+    if (su) {
+      return su;
+    } else {
+      const runningTask = this._runningTasks.find((t) => t.meta === path);
+      if (runningTask) {
+        return await runningTask.promise;
+      } else {
+        throw new Error('no source unit available for this path');
+      }
+    }
+  }
+
+  async find(criteria) {
+    return new Promise((resolve, reject) => {
+      return resolve(this.findSync(criteria));
+    });
+  }
+
+  findSync(criteria) {
+    return Object.values(this.sourceUnits).filter((sourceUnit) =>
+      criteria(sourceUnit)
+    );
+  }
+
+  async findContractsByName(name) {
+    return new Promise((resolve, reject) => {
+      return resolve(this.findContractsByNameSync(name));
+    });
+  }
+
+  findContractsByNameSync(name) {
+    return this.findSync((su) => su.contracts.hasOwnProperty(name)).map(
+      (su) => su.contracts[name]
+    );
+  }
+
+  getAllContracts(asObject) {
+    let contracts = Object.values(this.sourceUnits)
+      .map((su) => Object.values(su.contracts))
+      .flat(1);
+    if (asObject) {
+      return contracts.reduce(function (acc, cur, i) {
+        acc[cur.name] = cur;
+        return acc;
+      }, {});
+    }
+    return contracts;
+  }
+
+  /** internal */
+
+  _updateInheritedNames(contract, subcontract) {
+    if (contract.resolvedInheritance === true) {
+      console.log(`inheritance for ${contract.name} already resolved`);
+      return;
     }
 
-    update() {
-        this._resolveDependencies();
-        this._resolveExternalCalls2ndPass();
+    console.log(
+      `updating inherited names for contract ${contract.name}, subcontract: ${subcontract.name}`
+    );
+
+    if (subcontract.name == contract.name) {
+      return; //skip self
     }
 
-    /** GETTER */
-    get(key) {
-        return this.sourceUnits[key];
+    if (subcontract._node.kind === 'interface') {
+      //only consider structs
+      for (let _var in subcontract.structs) {
+        contract.inherited_names[_var] = subcontract;
+        contract.inherited_structs[_var] = subcontract.structs[_var];
+      }
+      return; //skip other inherited names from interfaces
     }
 
-    async getSourceUnitByPath(path) {
-        return new Promise((resolve, reject) => {
-            const su = this.sourceUnits[path]
-            if (su) {
-                resolve(su)
+    for (let _var in subcontract.stateVars) {
+      if (subcontract.stateVars[_var].visibility != 'private') {
+        contract.inherited_names[_var] = subcontract;
+      }
+    }
+    for (let _var of subcontract.functions) {
+      if (_var._node.visibility != 'private') {
+        contract.inherited_names[_var.name] = subcontract;
+      }
+    }
+    for (let _var of subcontract.events) {
+      if (_var._node.visibility != 'private') {
+        contract.inherited_names[_var.name] = subcontract;
+      }
+    }
+    for (let _var in subcontract.modifiers) {
+      if (subcontract.modifiers[_var].visibility != 'private') {
+        contract.inherited_names[_var] = subcontract;
+      }
+    }
+    for (let _var in subcontract.enums) {
+      if (subcontract.enums[_var].visibility != 'private') {
+        contract.inherited_names[_var] = subcontract;
+      }
+    }
+    for (let _var in subcontract.structs) {
+      contract.inherited_names[_var] = subcontract;
+      contract.inherited_structs[_var] = subcontract.structs[_var];
+    }
+    for (let _var in subcontract.mappings) {
+      if (subcontract.mappings[_var].visibility != 'private') {
+        contract.inherited_names[_var] = subcontract;
+      }
+    }
+  }
+
+  //if currentSourceUnit != undefined, only propagate inherited names for the current source unit path (for performances)
+  //excepted if resolveAllInheritance is set, then we resolve for all known source units.
+  _resolveDepsAndPropagateInheritedNames(
+    currentSourceUnit,
+    resolveAllInheritance = false
+  ) {
+    let allContracts = this.getAllContracts(true);
+    let dependencyMap = Object.values(allContracts).reduce((acc, cur) => {
+      acc[cur.name] = cur.dependencies;
+      return acc;
+    }, {});
+
+    if (this.options.resolveInheritance) {
+      //resolve imported structs for each source unit
+      //note: we only resolve imports for source units defined outside contracts.
+      this._propagateImportStructs();
+    }
+
+    Object.entries(linearize(dependencyMap, { reverse: true })).forEach(
+      ([contractName, linearizedDeps]) => {
+        const contractObj = allContracts[contractName];
+        if (contractObj) {
+          //ignore contracts we dont know yet (missing import?)
+          const su = contractObj._parent; //sourceUnit
+          const resolveInheritance =
+            this.options.resolveInheritance &&
+            (su.filePath === currentSourceUnit || resolveAllInheritance);
+          allContracts[contractName].linearizedDependencies =
+            linearizedDeps
+              .filter((depName) => depName !== contractName)
+              .map((depContractName) => {
+                let depContractObj = allContracts[depContractName];
+                if (depContractObj) {
+                  if (resolveInheritance)
+                    //only resolve for the current source unit
+                    this._updateInheritedNames(contractObj, depContractObj);
+                  return depContractObj;
+                }
+                return depContractName; //not found
+              }) || [];
+          contractObj.resolvedInheritance = contractObj.resolvedInheritance || resolveInheritance; //only resolve inheritance once
+        }
+      }
+    );
+  }
+
+  _propagateImportStructs() {
+    //build the import graph
+    let importMap = Object.values(this.sourceUnits).reduce((acc, cur) => {
+      acc[path.basename(cur.filePath)] = cur.imports.flatMap((imp) =>
+        path.basename(imp.path)
+      );
+      return acc;
+    }, {});
+
+    //Do a DFS in the graph to pull the inherited structs from imports.
+    //Should not contain cycles (no cyclic imports)
+    //For each S.U., DFS guarantees that we resolve imports from childrens before.
+    const toVisit = Object.keys(importMap);
+    const visited = {};
+    let order = [];
+    let idx = 1;
+    while (toVisit.length > 0) {
+      //loop through all source units
+      let tmp = toVisit.pop();
+      while (visited[tmp]) {
+        tmp = toVisit.pop();
+      }
+      const stack = [tmp];
+      while (stack.length > 0) {
+        //inner DFS loop
+        const cur = stack.pop();
+        if (importMap[cur])
+          stack.push(...importMap[cur].filter((v) => !visited[v]));
+        if (!visited[cur]) {
+          //avoid looping if cycles
+          visited[cur] = idx;
+          idx += 1;
+          order.push(cur);
+        }
+      }
+      //pull imports for each source unit
+      order.reverse().forEach((suName) => {
+        const su = this.sourceUnitNametoSourceUnit[suName];
+        if (su) {
+          importMap[suName].forEach((imp) => {
+            const impSu = this.sourceUnitNametoSourceUnit[imp];
+            if (impSu) {
+              Object.assign(su.structs, impSu.structs);
+            }
+          });
+        }
+      });
+      order = [];
+    }
+  }
+
+  _resolveExternalCalls2ndPass() {
+    Object.values(this.sourceUnits).forEach((su) => {
+      Object.values(
+        su.getExternalCalls(
+          (c) => c.callType === 'external' || c.callType === 'inconclusive'
+        )
+      ).forEach((c) => {
+        switch (c.type) {
+          case 'memberAccessOfVar':
+            // 2nd pass check if the typename target turns out to be a library call. in that case, remove it from external call list
+            if (
+              !c.declaration ||
+              !c.declaration.typeName ||
+              !c.declaration.typeName.namePath
+            ) {
+              return; // skip broken
+            }
+
+            let functionImplementationFound = false;
+
+            let fcandidates = [
+              c.declaration.typeName.namePath, //complete typename
+              c.declaration.typeName.namePath.split('.', 1)[0], //typename split
+            ];
+
+            if (c._helper && c._helper.contract) {
+              //add usingFor refs if we know them
+              fcandidates = fcandidates.concat(
+                ...c._helper.contract
+                  ._existsUsingForDeclaration(c.declaration.typeName.namePath)
+                  .map((uf) => uf.libraryName)
+              );
+            }
+
+            for (let typename of new Set(fcandidates)) {
+              //check if typename is a LIBRARY contract known to the system;
+              let found = this.findSync(
+                (su) =>
+                  su.contracts.hasOwnProperty(typename) &&
+                  su.contracts[typename]._node.kind == 'library'
+              );
+              if (found.length) {
+                // we have found a LIBRARY contract.
+                // check if the contract exports our function. --> likely, not an extcall ELSE extcall
+                functionImplementationFound = !!(
+                  found[0][typename] &&
+                  found[0][typename].name &&
+                  found[0][typename].names[c.name]
+                );
+                if (functionImplementationFound) {
+                  break;
+                }
+              }
+            }
+
+            if (!functionImplementationFound) {
+              //assume external call
+              c.type = 'memberAccessOfVar';
+              c.callType = 'external';
             } else {
-                const runningTask = this._runningTasks.find(t => t.meta === path)
-                if (runningTask) {
-                    runningTask.promise.then(res => resolve(res)).catch(err => reject(err));
-                } else {
-                    reject('no source unit available for this path')
-                }
-            } 
-        })
-    }
-
-    async find(criteria) {
-        return new Promise((resolve, reject) => {
-            return resolve(this.findSync(criteria));
-        });
-    }
-
-    findSync(criteria) {
-        return Object.values(this.sourceUnits).filter(sourceUnit => criteria(sourceUnit));
-    }
-
-    async findContractsByName(name) {
-        return new Promise((resolve, reject) => {
-            return resolve(this.findContractsByNameSync(name));
-        });
-    }
-
-    findContractsByNameSync(name) {
-        return this.findSync(su => su.contracts.hasOwnProperty(name)).map(su => su.contracts[name]);
-    }
-
-    getAllContracts(asObject) {
-        let contracts = Object.values(this.sourceUnits).map(su => Object.values(su.contracts)).flat(1);
-        if (asObject) {
-            return contracts.reduce(function (acc, cur, i) {
-                acc[cur.name] = cur;
-                return acc;
-            }, {});
-        }
-        return contracts;
-    }
-
-    /** internal */
-
-    _updateInheritedNames(contract, subcontract) {
-        for (let _var in subcontract.stateVars) {
-            if (subcontract.stateVars[_var].visibility != "private") {
-                contract.inherited_names[_var] = subcontract;
+              c.type = undefined;
+              c.callType = undefined;
             }
-        }
-        for (let _var of subcontract.functions) {
-            if (_var._node.visibility != "private") {
-                contract.inherited_names[_var.name] = subcontract;
+
+            if (c._helper) {
+              c._helper = undefined;
             }
-        }
-        for (let _var of subcontract.events) {
-            if (_var._node.visibility != "private") {
-                contract.inherited_names[_var.name] = subcontract;
+
+            break;
+          case 'memberAccessOfUnknownIdentifier':
+            if (c.declaration) {
+              break; //skip, already resolved
             }
-        }
-        for (let _var in subcontract.modifiers) {
-            if (subcontract.modifiers[_var].visibility != "private") {
-                contract.inherited_names[_var] = subcontract;
+            // check if we finally know if this call points to a library call or not.
+            // c._helper contains the contract object. let's find the corresponding contracts
+            if (!c._helper) {
+              break;
             }
-        }
-        for (let _var in subcontract.enums) {
-            if (subcontract.enums[_var].visibility != "private") {
-                contract.inherited_names[_var] = subcontract;
+            let deps = c._helper.contract.linearizedDependencies;
+            const targetVarName = c._node.expression.expression.name;
+            let declaration = deps.find(
+              (depContract) =>
+                typeof depContract === 'object' &&
+                depContract.stateVars[targetVarName]
+            );
+            if (declaration) {
+              c.declaration = declaration.stateVars[targetVarName];
+              c.callType = 'external'; //update to external call
+              c.type = 'memberAccessOfUnknownIdentifierResolvedToInheritedSVar';
             }
+            c._helper = undefined;
+            break;
         }
-        for (let _var in subcontract.structs) {
-            if (subcontract.structs[_var].visibility != "private") {
-                contract.inherited_names[_var] = subcontract;
-            }
-        }
-        for (let _var in subcontract.mappings) {
-            if (subcontract.mappings[_var].visibility != "private") {
-                contract.inherited_names[_var] = subcontract;
-            }
-        }
-    }
-
-    _resolveDependencies() {
-        let allContracts = this.getAllContracts(true);
-        let dependencyMap = Object.values(allContracts).reduce((acc, cur) => {
-            acc[cur.name] = cur.dependencies;
-            return acc;
-        }, {});
-
-
-        if (this.options.resolveInheritedStructs) {
-            //resolve imported structs for each source unit
-            //note: we only resolve imports for source units defined outside contracts. 
-            this._propagateImportStructs()
-        }
-
-        Object.entries(linearize(dependencyMap, { reverse: true })).forEach(([contractName, linearizedDeps]) => {
-            if (allContracts[contractName]) { //ignore contracts we dont know yet (missing import?)
-                allContracts[contractName].linearizedDependencies = linearizedDeps.filter(depName => depName !== contractName).map(contractName => {
-                    let contractObjs = allContracts[contractName];
-                    if (contractObjs) {
-                        return contractObjs
-                    }
-                    return contractName; //not found
-                }) || [];
-            }
-        });
-    }
-
-    _propagateImportStructs() {
-        //build the import graph
-        let importMap = Object.values(this.sourceUnits).reduce((acc, cur) => {
-            acc[path.basename(cur.filePath)] = cur.imports.flatMap(imp => path.basename(imp.path));
-            return acc;
-        }, {});
-
-        //Do a DFS in the graph to pull the inherited structs from imports.
-        //Should not contain cycles (no cyclic imports)
-        //For each S.U., DFS guarantees that we resolve imports from childrens before.
-        const toVisit = Object.keys(importMap)
-        const visited = {}
-        let order = []
-        let idx = 1
-        while (toVisit.length > 0) {
-            //loop through all source units
-            let tmp = toVisit.pop()
-            while (visited[tmp]) {
-                tmp = toVisit.pop()
-            }
-            const stack = [tmp]
-            while(stack.length > 0) {
-                //inner DFS loop
-                const cur = stack.pop()
-                if (importMap[cur])
-                    stack.push(...importMap[cur].filter(v => !visited[v]))
-                if (!visited[cur]) {
-                    //avoid looping if cycles
-                    visited[cur] = idx
-                    idx += 1
-                    order.push(cur);
-                }   
-            }
-            //pull imports for each source unit
-            order.reverse().forEach(suName => {
-                const su = this.sourceUnitNametoSourceUnit[suName]
-                if (su) {
-                importMap[suName].forEach(imp => {
-                    const impSu = this.sourceUnitNametoSourceUnit[imp]
-                    if (impSu) {
-                        Object.assign(su.structs, impSu.structs)
-                    }
-                }) 
-                }
-            });
-            order = []
-        }
-    }
-
-    _resolveExternalCalls2ndPass() {
-        Object.values(this.sourceUnits).forEach(su => {
-            Object.values(su.getExternalCalls(c => c.callType === "external" || c.callType === "inconclusive")).forEach(c => {
-                switch (c.type) {
-                    case "memberAccessOfVar":
-                        // 2nd pass check if the typename target turns out to be a library call. in that case, remove it from external call list
-                        if (!c. declaration || !c.declaration.typeName || !c.declaration.typeName.namePath) {
-                            return; // skip broken
-                        }
-
-                        let functionImplementationFound = false;
-
-                        let fcandidates = [
-                            c.declaration.typeName.namePath, //complete typename
-                            c.declaration.typeName.namePath.split(".", 1)[0], //typename split
-                        ];
-
-                        if(c._helper && c._helper.contract) { //add usingFor refs if we know them
-                            fcandidates = fcandidates.concat(...c._helper.contract._existsUsingForDeclaration(c.declaration.typeName.namePath).map(uf => uf.libraryName))
-                        }
-
-                        for(let typename of new Set(fcandidates)){
-                        
-                            //check if typename is a LIBRARY contract known to the system;
-                            let found = this.findSync(su => su.contracts.hasOwnProperty(typename) && su.contracts[typename]._node.kind == "library");
-                            if (found.length){
-                                // we have found a LIBRARY contract.
-                                // check if the contract exports our function. --> likely, not an extcall ELSE extcall
-                                functionImplementationFound = !!(found[0][typename] && found[0][typename].name && found[0][typename].names[c.name]);
-                                if(functionImplementationFound){
-                                    break;
-                                }
-                            }
-                        }
-
-                        if(!functionImplementationFound){
-                            //assume external call
-                            c.type = "memberAccessOfVar";
-                            c.callType = "external";   
-                        } else {
-                            c.type = undefined;
-                            c.callType = undefined; 
-                        }
-
-                        if(c._helper) {
-                            c._helper = undefined
-                        }
-                    
-                        break;
-                    case "memberAccessOfUnknownIdentifier":
-                        if (c.declaration) {
-                            break; //skip, already resolved
-                        }
-                        // check if we finally know if this call points to a library call or not.
-                        // c._helper contains the contract object. let's find the corresponding contracts
-                        if(!c._helper){
-                            break;
-                        }
-                        let deps = c._helper.contract.linearizedDependencies;
-                        const targetVarName = c._node.expression.expression.name;
-                        let declaration = deps.find(depContract => typeof depContract === "object" && depContract.stateVars[targetVarName]);
-                        if (declaration) {
-                            c.declaration = declaration.stateVars[targetVarName];
-                            c.callType = "external";  //update to external call
-                            c.type = "memberAccessOfUnknownIdentifierResolvedToInheritedSVar";
-                        }
-                        c._helper = undefined
-                        break;
-                }
-            });
-        });
-    }
+      });
+    });
+  }
 }
 
 class SourceUnit {
-    constructor(workspace) {
-        this.workspace = workspace;
-        this.filePath = undefined;
-        this.ast = undefined;
-        this.contracts = {};
-        this.pragmas = [];
-        this.imports = [];
-        this.structs = {}; //structs defined outside contract scope
-        this.hash = undefined;
+  constructor(workspace) {
+    this.workspace = workspace;
+    this.filePath = undefined;
+    this.ast = undefined;
+    this.contracts = {};
+    this.pragmas = [];
+    this.imports = [];
+    this.structs = {}; //structs defined outside contract scope
+    this.hash = undefined;
+  }
+
+  toJSON() {
+    return this.ast;
+  }
+
+  clone() {
+    return Object.assign(new SourceUnit(this.workspace), this);
+  }
+
+  fromFile(fpath) {
+    const { filePath, content } = SourceUnit.getFileContent(fpath); // returns {fpath, content}
+    this.filePath = filePath;
+    console.log(`→ fromFile(): ${this.filePath}`);
+    this.fromSource(content);
+    return this;
+  }
+
+  fromSource(content) {
+    this.hash = SourceUnit.getHash(content);
+    console.log(`→ fromSource(): hash=${this.hash}`);
+    /** cache-lookup first */
+    let cached = this.workspace.sourceUnitsCache.get(this.hash);
+    if (cached) {
+      console.log(`→ fromSource(): cache hit! (${cached.filePath})`);
+      throw new CacheHit(cached);
     }
 
-    toJSON(){
-        return this.ast;
+    /** parser magic */
+    this.parseAst(content);
+
+    /** linearize imports */
+
+    /** resolve idents */
+    if (this.workspace.options.resolveIdentifiers) {
+      this._resolveIdentifiers();
+    }
+  }
+
+  parseAst(input) {
+    console.log(' * parseAst()');
+    this.ast = parser.parse(input, { loc: true, tolerant: true });
+
+    if (typeof this.ast === 'undefined') {
+      throw new ParserError('Parser failed to parse file.');
     }
 
-    clone() {
-        return Object.assign(new SourceUnit(this.workspace), this);
+    /** AST rdy */
+
+    var this_sourceUnit = this;
+
+    parser.visit(this.ast, {
+      PragmaDirective(node) {
+        this_sourceUnit.pragmas.push(node);
+      },
+      ImportDirective(node) {
+        this_sourceUnit.imports.push(node);
+      },
+      StructDefinition(node, _parent) {
+        if (_parent.type === 'SourceUnit')
+          this_sourceUnit.structs[node.name] = node;
+      },
+      ContractDefinition(node) {
+        this_sourceUnit.contracts[node.name] = new Contract(
+          this_sourceUnit,
+          node
+        );
+      },
+    });
+    /*** also import dependencies? */
+    return this;
+  }
+
+  /**
+   * Experimental flatten: replaces imports with imported files content.
+   */
+  flatten() {
+    function replaceImports(content) {
+      return content
+        .replace(/\w*(import[^;]+)/gi, '////$1')
+        .replace(
+          /(\/\/ SPDX-License-Identifier)/gi,
+          '////$1-FLATTEN-SUPPRESS-WARNING'
+        );
     }
 
-    fromFile(fpath) {
-        const { filePath, content } = SourceUnit.getFileContent(fpath);  // returns {fpath, content}
-        this.filePath = filePath;
-        console.log(`→ fromFile(): ${this.filePath}`);
-        this.fromSource(content);
-        return this;
-    }
+    let seen = [];
 
-    fromSource(content) {
-        this.hash = SourceUnit.getHash(content);
-        console.log(`→ fromSource(): hash=${this.hash}`);
-        /** cache-lookup first */
-        let cached = this.workspace.sourceUnitsCache[this.hash];
-        if (cached) {
-            console.log(`→ fromSource(): cache hit! (${cached.filePath})`);
-            throw new CacheHit(cached);
+    let filesToMerge = this._fsFindImportsRecursive()
+      .reverse()
+      .filter((item) => {
+        if (seen.includes(item)) {
+          return false;
         }
+        seen.push(item);
+        return true;
+      });
 
-        /** parser magic */
-        this.parseAst(content);
-
-        /** linearize imports */
-
-        /** resolve idents */
-        if (this.workspace.options.resolveIdentifiers) {
-            this._resolveIdentifiers();
-        }
-    }
-
-    parseAst(input) {
-        console.log(" * parseAst()");
-        this.ast = parser.parse(input, { loc: true, tolerant: true });
-
-        if (typeof this.ast === "undefined") {
-            throw new ParserError("Parser failed to parse file.");
-        }
-
-        /** AST rdy */
-
-        var this_sourceUnit = this;
-
-        parser.visit(this.ast, {
-            PragmaDirective(node) { this_sourceUnit.pragmas.push(node); },
-            ImportDirective(node) { this_sourceUnit.imports.push(node); },
-            StructDefinition(node, _parent) { if(_parent.type === "SourceUnit") this_sourceUnit.structs[node.name] = node },
-            ContractDefinition(node) {
-                this_sourceUnit.contracts[node.name] = new Contract(this_sourceUnit, node);
-            },
-        });
-        /*** also import dependencies? */
-        return this;
-    }
-
-    /**
-     * Experimental flatten: replaces imports with imported files content.
-     */
-    flatten() {
-        function replaceImports(content) {
-            return content.replace(/\w*(import[^;]+)/ig, "////$1").replace(/(\/\/ SPDX-License-Identifier)/ig, "////$1-FLATTEN-SUPPRESS-WARNING");
-        }
-
-        let seen = [];
-
-        let filesToMerge = this._fsFindImportsRecursive().reverse().filter(item => {
-            if (seen.includes(item)) {
-                return false;
-            }
-            seen.push(item);
-            return true;
-        });
-
-        let flattened = filesToMerge.map(fpath => {
-            return `
+    let flattened = filesToMerge
+      .map((fpath) => {
+        return `
 /** 
  *  SourceUnit: ${this.filePath}
 */
             
 ${replaceImports(fs.readFileSync(fpath).toString('utf-8'))}
 `;
-        }).join("\n\n");
-        return flattened + `
+      })
+      .join('\n\n');
+    return (
+      flattened +
+      `
 /** 
  *  SourceUnit: ${this.filePath}
 */
 
 ${replaceImports(fs.readFileSync(this.filePath).toString('utf-8'))}
-`;
+`
+    );
+  }
 
+  static getFileContent(fpath) {
+    if (!fs.existsSync(fpath)) {
+      throw Error(`File '${fpath}' does not exist.`);
     }
+    const filePath = path.resolve(fpath);
+    const content = fs.readFileSync(filePath).toString('utf-8');
+    return { filePath, content };
+  }
 
-    static getFileContent(fpath) {
-        if (!fs.existsSync(fpath)) {
-            throw Error(`File '${fpath}' does not exist.`);
+  // mainly used to get the filehash while "half-preparing" the source-unit object
+  static getFileHash(fpath) {
+    const { _, content } = SourceUnit.getFileContent(fpath);
+    return SourceUnit.getHash(content);
+  }
+
+  static getHash(content) {
+    return crypto.createHash('sha1').update(content).digest('hex');
+  }
+
+  _fsFindImportsRecursive() {
+    let imports = this._fsFindImports();
+    imports = imports.concat(
+      imports
+        .map((fspath) => this.workspace.get(fspath)._fsFindImportsRecursive())
+        .flat(1)
+    );
+    return imports;
+  }
+
+  _fsFindImports() {
+    /** parse imports */
+    console.log('  * parseImports()');
+    let result = [];
+    let sourceUnit = this;
+
+    this.imports.forEach(async (imp) => {
+      //basedir
+
+      let relativeNodeModules = function () {
+        let basepath = sourceUnit.filePath.split('/contracts/');
+
+        if (basepath.length == 2) {
+          //super dirty
+          basepath = basepath[0];
+          return path.resolve(basepath + '/node_modules/' + imp.path);
         }
-        const filePath = path.resolve(fpath);
-        const content = fs.readFileSync(filePath).toString('utf-8');
-        return { filePath, content };
-    }
+      };
 
-    // mainly used to get the filehash while "half-preparing" the source-unit object
-    static getFileHash(fpath) {
-        const { _, content } = SourceUnit.getFileContent(fpath);
-        return SourceUnit.getHash(content);
-    }
-
-    static getHash(content) {
-        return crypto.createHash('sha1').update(content).digest('hex');
-    }
-
-    _fsFindImportsRecursive() {
-        let imports = this._fsFindImports();
-        imports = imports.concat(imports.map(fspath => this.workspace.get(fspath)._fsFindImportsRecursive()).flat(1));
-        return imports;
-    }
-
-    _fsFindImports() {
-        /** parse imports */
-        console.log("  * parseImports()");
-        let result = [];
-        let sourceUnit = this;
-
-        this.imports.forEach(async imp => {
-
-            //basedir
-
-            let relativeNodeModules = function () {
-                let basepath = sourceUnit.filePath.split("/contracts/");
-
-                if (basepath.length == 2) { //super dirty
-                    basepath = basepath[0];
-                    return path.resolve(basepath + "/node_modules/" + imp.path);
-                }
-            };
-
-            let lastNodeModules = function () {
-                let basepath = sourceUnit.filePath.split("/node_modules/");
-                if (basepath.length >= 2) { //super dirty
-                    basepath = basepath.slice(0, basepath.length - 2).join("/");
-                    return path.resolve(basepath + "/node_modules/" + imp.path);
-                }
-            };
-
-            let firstNodeModules = function () {
-                let basepath = sourceUnit.filePath.split("/node_modules/");
-                if (basepath.length >= 2) { //super dirty
-                    basepath = basepath[0];
-                    return path.resolve(basepath + "/node_modules/" + imp.path);
-                }
-            };
-
-            let candidates = [
-                path.resolve(path.dirname(sourceUnit.filePath) + "/./" + imp.path),
-                path.resolve(path.dirname(sourceUnit.filePath) + "/node_modules/" + imp.path),
-                relativeNodeModules(),
-                lastNodeModules(),
-                firstNodeModules(),
-                //path.resolve(fileWorkspace + "/./" + imp.path),
-                //path.resolve(fileWorkspace + "/node_modules/" + imp.path)
-            ]
-                .concat(sourceUnit.workspace.basedirs.map(b => path.resolve(b + "/./" + imp.path)))
-                .concat(sourceUnit.workspace.basedirs.map(b => path.resolve(b + "/node_modules/" + imp.path)));
-
-            let importPath = candidates.find(_importPath => _importPath && fs.existsSync(_importPath));
-            if (importPath !== undefined) {
-                result.push(importPath);
-            } else {
-                console.error(`[ERR] Import not found: '${imp.path}' referenced in '${sourceUnit.filePath}'`);
-            }
-        }, this);
-
-        return result;
-    }
-
-    _resolveIdentifiers() {
-        console.log("  * _resolveIdentifiers()");
-        /*** resolve identifier scope */
-        for (var contract in this.contracts) {
-            for (var func of Object.values(this.contracts[contract].functions).concat(Object.values(this.contracts[contract].modifiers))) {
-                func.identifiers.forEach(identifier => {
-                    identifier.declarations = {
-                        local: [],
-                        global: typeof this.contracts[contract].stateVars[identifier.name] == "undefined" ? [] : this.contracts[contract].stateVars[identifier.name]
-                    };
-
-                    if (typeof this.contracts[contract].stateVars[identifier.name] != "undefined") {
-                        this.contracts[contract].stateVars[identifier.name].extra.usedAt.push(identifier);
-                        func.accesses_svar = true;  // TODO: also check for inherited svars 
-                    }
-
-                    for (let identDec in func.arguments) {
-                        if (identifier.name == identDec) {
-                            identifier.declarations.local.push(func.arguments[identDec]);
-                        }
-                    }
-                    for (let identDec in func.returns) {
-                        if (identifier == identDec) {
-                            identifier.declarations.local.push(func.returns[identDec]);
-                        }
-                    }
-                });
-            }
+      let lastNodeModules = function () {
+        let basepath = sourceUnit.filePath.split('/node_modules/');
+        if (basepath.length >= 2) {
+          //super dirty
+          basepath = basepath.slice(0, basepath.length - 2).join('/');
+          return path.resolve(basepath + '/node_modules/' + imp.path);
         }
-    }
+      };
 
-    _findImportedContract(searchName) {
-        for (var contractName in this.contracts) {
-            if (this.contracts[contractName].name == searchName) {
-                return this.contracts[contractName];
-            }
+      let firstNodeModules = function () {
+        let basepath = sourceUnit.filePath.split('/node_modules/');
+        if (basepath.length >= 2) {
+          //super dirty
+          basepath = basepath[0];
+          return path.resolve(basepath + '/node_modules/' + imp.path);
         }
-        //check imports
-        var BreakException = {};
+      };
 
-        let result;
-        this.imports.forEach(function (imp) {
-            if (typeof result != "undefined") {
-                return;
+      let candidates = [
+        path.resolve(path.dirname(sourceUnit.filePath) + '/./' + imp.path),
+        path.resolve(
+          path.dirname(sourceUnit.filePath) + '/node_modules/' + imp.path
+        ),
+        relativeNodeModules(),
+        lastNodeModules(),
+        firstNodeModules(),
+        //path.resolve(fileWorkspace + "/./" + imp.path),
+        //path.resolve(fileWorkspace + "/node_modules/" + imp.path)
+      ]
+        .concat(
+          sourceUnit.workspace.basedirs.map((b) =>
+            path.resolve(b + '/./' + imp.path)
+          )
+        )
+        .concat(
+          sourceUnit.workspace.basedirs.map((b) =>
+            path.resolve(b + '/node_modules/' + imp.path)
+          )
+        );
+
+      let importPath = candidates.find(
+        (_importPath) => _importPath && fs.existsSync(_importPath)
+      );
+      if (importPath !== undefined) {
+        result.push(importPath);
+      } else {
+        console.error(
+          `[ERR] Import not found: '${imp.path}' referenced in '${sourceUnit.filePath}'`
+        );
+      }
+    }, this);
+
+    return result;
+  }
+
+  _resolveIdentifiers() {
+    console.log('  * _resolveIdentifiers()');
+    /*** resolve identifier scope */
+    for (var contract in this.contracts) {
+      for (var func of Object.values(this.contracts[contract].functions).concat(
+        Object.values(this.contracts[contract].modifiers)
+      )) {
+        func.identifiers.forEach((identifier) => {
+          identifier.declarations = {
+            local: [],
+            global:
+              typeof this.contracts[contract].stateVars[identifier.name] ==
+              'undefined'
+                ? []
+                : this.contracts[contract].stateVars[identifier.name],
+          };
+
+          if (
+            typeof this.contracts[contract].stateVars[identifier.name] !=
+            'undefined'
+          ) {
+            this.contracts[contract].stateVars[
+              identifier.name
+            ].extra.usedAt.push(identifier);
+            func.accesses_svar = true; // TODO: also check for inherited svars
+          }
+
+          for (let identDec in func.arguments) {
+            if (identifier.name == identDec) {
+              identifier.declarations.local.push(func.arguments[identDec]);
             }
-            let contract = this._findImportedContract(imp.ast, searchName);
-            if (typeof contract != "undefined" && contract.name == searchName) {
-                result = contract;
+          }
+          for (let identDec in func.returns) {
+            if (identifier == identDec) {
+              identifier.declarations.local.push(func.returns[identDec]);
             }
+          }
         });
-        return result;
+      }
     }
+  }
 
-    getContractAtLocation(line, column) {
-        for (let c of Object.keys(this.contracts)) {
-            let loc = this.contracts[c]._node.loc;
-            if (line < loc.start.line) {
-                continue;
-            } else if (line == loc.start.line && column < loc.start.column) {
-                continue;
-            } else if (line == loc.end.line && column > loc.end.column) {
-                continue;
-            } else if (line > loc.end.line) {
-                continue;
-            }
-
-            return this.contracts[c];
-        }
+  _findImportedContract(searchName) {
+    for (var contractName in this.contracts) {
+      if (this.contracts[contractName].name == searchName) {
+        return this.contracts[contractName];
+      }
     }
+    //check imports
+    let result;
+    this.imports.forEach(function (imp) {
+      if (typeof result != 'undefined') {
+        return;
+      }
+      let contract = this._findImportedContract(imp.ast, searchName);
+      if (typeof contract != 'undefined' && contract.name == searchName) {
+        result = contract;
+      }
+    });
+    return result;
+  }
 
-    getFunctionAtLocation(line, column) {
-        let contract = this.getContractAtLocation(line, column);
-        if (!contract) {
-            return;
-        }
-        for (let f of contract.functions) {
-            let loc = f._node.loc;
-            if (line < loc.start.line) {
-                continue;
-            } else if (line == loc.start.line && column < loc.start.column) {
-                continue;
-            } else if (line == loc.end.line && column > loc.end.column) {
-                continue;
-            } else if (line > loc.end.line) {
-                continue;
-            }
+  getContractAtLocation(line, column) {
+    for (let c of Object.keys(this.contracts)) {
+      let loc = this.contracts[c]._node.loc;
+      if (line < loc.start.line) {
+        continue;
+      } else if (line == loc.start.line && column < loc.start.column) {
+        continue;
+      } else if (line == loc.end.line && column > loc.end.column) {
+        continue;
+      } else if (line > loc.end.line) {
+        continue;
+      }
 
-            return { contract, function: f };
-        }
-        return { contract };
+      return this.contracts[c];
     }
+  }
 
-    getExternalCalls(criteria) {
-        return Object.values(this.contracts).reduce((acc, contract) => acc = acc.concat(contract.getExternalCalls(criteria)), []);
+  getFunctionAtLocation(line, column) {
+    let contract = this.getContractAtLocation(line, column);
+    if (!contract) {
+      return;
     }
+    for (let f of contract.functions) {
+      let loc = f._node.loc;
+      if (line < loc.start.line) {
+        continue;
+      } else if (line == loc.start.line && column < loc.start.column) {
+        continue;
+      } else if (line == loc.end.line && column > loc.end.column) {
+        continue;
+      } else if (line > loc.end.line) {
+        continue;
+      }
 
-    getAllContractStructs() {
-        return Object.values(this.contracts).reduce((acc, contract) => acc = acc.concat(contract.structs), []);
+      return { contract, function: f };
     }
-  
+    return { contract };
+  }
+
+  getExternalCalls(criteria) {
+    return Object.values(this.contracts).reduce(
+      (acc, contract) =>
+        (acc = acc.concat(contract.getExternalCalls(criteria))),
+      []
+    );
+  }
+
+  getAllContractStructs() {
+    return Object.values(this.contracts).reduce(
+      (acc, contract) => (acc = acc.concat(contract.structs)),
+      []
+    );
+  }
 }
 
 class Contract {
-    constructor(_parent, node) {
-        this._parent = _parent;
-        this._node = node;
-        this.name = node.name;
-        this.dependencies = node.baseContracts.map(spec => spec.baseName.namePath);
-        this.linearizedDependencies = []; // will be updated in a later step
-        this.stateVars = {};  // pure statevars --> see names
-        this.enums = {};  // enum declarations
-        this.structs = {}; // struct declarations
-        this.mappings = {};  // mapping declarations
-        this.modifiers = {};  // modifier declarations
-        this.functions = [];  // function and method declarations; can be overloaded
-        this.constructor = null;  // ...
-        this.events = [];  // event declarations; can be overloaded
-        this.inherited_names = {};  // all names inherited from other contracts
-        this.inherited_structs = {..._parent.structs}; // structs inherited from source unit.
-        this.names = {};   // all names in current contract (methods, events, structs, ...)
-        this.usingFor = {}; // using XX for YY
+  constructor(_parent, node) {
+    this._parent = _parent;
+    this._node = node;
+    this.name = node.name;
+    this.dependencies = node.baseContracts.map(
+      (spec) => spec.baseName.namePath
+    );
+    this.linearizedDependencies = []; // will be updated in a later step
+    this.stateVars = {}; // pure statevars --> see names
+    this.enums = {}; // enum declarations
+    this.structs = {}; // struct declarations
+    this.mappings = {}; // mapping declarations
+    this.modifiers = {}; // modifier declarations
+    this.functions = []; // function and method declarations; can be overloaded
+    this.constructor = null; // ...
+    this.events = []; // event declarations; can be overloaded
+    this.inherited_names = {}; // all names inherited from other contracts
+    this.inherited_structs = { ..._parent.structs }; // structs inherited from source unit.
+    this.resolvedInheritance = false; //optimization: indicates if we already resolved inherited identifiers
+    this.names = {}; // all names in current contract (methods, events, structs, ...)
+    this.usingFor = {}; // using XX for YY
 
-        this._processAst(node);
-    }
+    this._processAst(node);
+  }
 
-    toJSON(){
-        return this._node;
-    }
+  toJSON() {
+    return this._node;
+  }
 
-    _processAst(node) {
+  _processAst(node) {
+    var current_function = null;
+    let current_contract = this;
 
-        var current_function = null;
-        let current_contract = this;
-
-        parser.visit(node, {
-
-            StateVariableDeclaration(_node) {
-                parser.visit(_node, {
-                    VariableDeclaration(__node) {
-                        __node.extra = { usedAt: [] };
-                        current_contract.stateVars[__node.name] = __node;
-                        current_contract.names[__node.name] = __node;
-                    }
-                });
-            },
-            // --> is a subtype. Mapping(_node){current_contract.mappings[_node.name]=_node},
-            Mapping(_node) {
-                current_contract.mappings[_node.name] = _node;
-            },
-            EnumDefinition(_node) {
-                current_contract.enums[_node.name] = _node;
-                current_contract.names[_node.name] = _node;
-            },
-            StructDefinition(_node) {
-                current_contract.structs[_node.name] = _node;
-                current_contract.names[_node.name] = _node;
-            },
-            UsingForDeclaration(_node) {
-                current_contract.usingFor[_node.libraryName] = _node;
-            },
-            ConstructorDefinition(_node) {
-                current_contract.constructor = _node;
-                current_contract.names[_node.name] = _node;
-            }, // wrong def in code: https://github.com/solidityj/solidity-antlr4/blob/fbe865f8ba510cbdb1540fcf9517a42820a4d097/Solidity.g4#L78 for consttuctzor () ..
-            ModifierDefinition(_node) {
-                current_function = new FunctionDef(current_contract, _node, "modifier");
-                current_contract.modifiers[_node.name] = current_function;
-                current_contract.names[_node.name] = current_function;
-            },
-            EventDefinition(_node) {
-                current_function = {
-                    _node: _node,
-                    name: _node.name,
-                    arguments: {},  // declarations: quick access to argument list
-                    declarations: {},  // all declarations: arguments+returns+body
-                };
-                current_contract.events.push(current_function);
-
-                current_contract.names[_node.name] = current_function;
-                // parse function body to get all function scope params.
-                // first get declarations
-                parser.visit(_node.parameters, {
-                    VariableDeclaration: function (__node) {
-                        current_function.arguments[__node.name] = __node;
-                        current_function.declarations[__node.name] = __node;
-                    }
-                });
-
-            },
-            FunctionDefinition(_node) {
-                let newFunc = new FunctionDef(current_contract, _node);
-                current_contract.functions.push(newFunc);
-                current_contract.names[_node.name] = newFunc;
-            },
+    parser.visit(node, {
+      StateVariableDeclaration(_node) {
+        parser.visit(_node, {
+          VariableDeclaration(__node) {
+            __node.extra = { usedAt: [] };
+            current_contract.stateVars[__node.name] = __node;
+            current_contract.names[__node.name] = __node;
+          },
         });
-    }
+      },
+      // --> is a subtype. Mapping(_node){current_contract.mappings[_node.name]=_node},
+      Mapping(_node) {
+        current_contract.mappings[_node.name] = _node;
+      },
+      EnumDefinition(_node) {
+        current_contract.enums[_node.name] = _node;
+        current_contract.names[_node.name] = _node;
+      },
+      StructDefinition(_node) {
+        current_contract.structs[_node.name] = _node;
+        current_contract.names[_node.name] = _node;
+      },
+      UsingForDeclaration(_node) {
+        current_contract.usingFor[_node.libraryName] = _node;
+      },
+      ConstructorDefinition(_node) {
+        current_contract.constructor = _node;
+        current_contract.names[_node.name] = _node;
+      }, // wrong def in code: https://github.com/solidityj/solidity-antlr4/blob/fbe865f8ba510cbdb1540fcf9517a42820a4d097/Solidity.g4#L78 for consttuctzor () ..
+      ModifierDefinition(_node) {
+        current_function = new FunctionDef(current_contract, _node, 'modifier');
+        current_contract.modifiers[_node.name] = current_function;
+        current_contract.names[_node.name] = current_function;
+      },
+      EventDefinition(_node) {
+        current_function = {
+          _node: _node,
+          name: _node.name,
+          arguments: {}, // declarations: quick access to argument list
+          declarations: {}, // all declarations: arguments+returns+body
+        };
+        current_contract.events.push(current_function);
 
-    getExternalCalls(criteria) {
-        // functions and modifiers
-        return [
-            ...this.functions.reduce((acc, cur) => acc.concat(cur.getExternalCalls(criteria)), []), 
-            ...Object.values(this.modifiers).reduce((acc, cur) => acc.concat(cur.getExternalCalls(criteria)), [])];
-    }
-
-    _existsUsingForDeclaration(typeName) {
-        return Object.values(this.usingFor).filter(uf => {
-            if (!uf.typeName) {
-                return true; //uf.typeName is null if this is a "usingFor *""
-            }
-            return uf.typeName.type == "ElementaryTypeName" ? uf.typeName.name == typeName : uf.typeName.namePath == typeName;
-        })
-    }
-}
-
-class FunctionDef {
-    constructor(parent, _node, _type) {
-        this.parent = parent;
-        this._node = _node;
-        this._type = _type || "function";
-        this.name = _node.name;
-        this.visibility = _node?.visibility //visibility
-        this.modifiers = {};   // quick access to modifiers
-        this.arguments = {};  // declarations: quick access to argument list
-        this.returns = {};  // declarations: quick access to return argument list
-        this.declarations = {};  // all declarations: arguments+returns+body
-        this.identifiers = [];  // all identifiers (use of variables)
-        this.complexity = 0;    // we just count nr. of branching statements here
-        this.accesses_svar = false; //
-        this.calls = [];  // internal and external calls
-        this.assemblyFunctions = {};  // list of assembly functions
-
-        this._processAst(_node);
-    }
-
-    toJSON(){
-        return this._node;
-    }
-
-    _processAst(_node) {
-        let current_function = this;
-        let current_contract = this.parent;
-
+        current_contract.names[_node.name] = current_function;
         // parse function body to get all function scope params.
         // first get declarations
         parser.visit(_node.parameters, {
-            VariableDeclaration: function (__node) {
-                current_function.arguments[__node.name] = __node;
-                current_function.declarations[__node.name] = __node;
-            }
+          VariableDeclaration: function (__node) {
+            current_function.arguments[__node.name] = __node;
+            current_function.declarations[__node.name] = __node;
+          },
         });
-        if (current_function._type == "function") {
-            parser.visit(_node.returnParameters, {
-                VariableDeclaration: function (__node) {
-                    current_function.arguments[__node.name] = __node;
-                    current_function.declarations[__node.name] = __node;
-                }
+      },
+      FunctionDefinition(_node) {
+        let newFunc = new FunctionDef(current_contract, _node);
+        current_contract.functions.push(newFunc);
+        current_contract.names[_node.name] = newFunc;
+      },
+    });
+  }
+
+  getExternalCalls(criteria) {
+    // functions and modifiers
+    return [
+      ...this.functions.reduce(
+        (acc, cur) => acc.concat(cur.getExternalCalls(criteria)),
+        []
+      ),
+      ...Object.values(this.modifiers).reduce(
+        (acc, cur) => acc.concat(cur.getExternalCalls(criteria)),
+        []
+      ),
+    ];
+  }
+
+  _existsUsingForDeclaration(typeName) {
+    return Object.values(this.usingFor).filter((uf) => {
+      if (!uf.typeName) {
+        return true; //uf.typeName is null if this is a "usingFor *""
+      }
+      return uf.typeName.type == 'ElementaryTypeName'
+        ? uf.typeName.name == typeName
+        : uf.typeName.namePath == typeName;
+    });
+  }
+}
+
+class FunctionDef {
+  constructor(parent, _node, _type) {
+    this.parent = parent;
+    this._node = _node;
+    this._type = _type || 'function';
+    this.name = _node.name;
+    this.visibility = _node?.visibility; //visibility
+    this.modifiers = {}; // quick access to modifiers
+    this.arguments = {}; // declarations: quick access to argument list
+    this.returns = {}; // declarations: quick access to return argument list
+    this.declarations = {}; // all declarations: arguments+returns+body
+    this.identifiers = []; // all identifiers (use of variables)
+    this.complexity = 0; // we just count nr. of branching statements here
+    this.accesses_svar = false; //
+    this.calls = []; // internal and external calls
+    this.assemblyFunctions = {}; // list of assembly functions
+
+    this._processAst(_node);
+  }
+
+  toJSON() {
+    return this._node;
+  }
+
+  _processAst(_node) {
+    let current_function = this;
+    let current_contract = this.parent;
+
+    // parse function body to get all function scope params.
+    // first get declarations
+    parser.visit(_node.parameters, {
+      VariableDeclaration: function (__node) {
+        current_function.arguments[__node.name] = __node;
+        current_function.declarations[__node.name] = __node;
+      },
+    });
+    if (current_function._type == 'function') {
+      parser.visit(_node.returnParameters, {
+        VariableDeclaration: function (__node) {
+          current_function.returns[__node.name] = __node;
+          current_function.declarations[__node.name] = __node;
+        },
+      });
+    }
+
+    /**** body declarations */
+    parser.visit(_node, {
+      VariableDeclaration(__node) {
+        current_function.declarations[__node.name] = __node;
+      },
+      /**
+       * subjective complexity - nr. of branching instructions
+       *   https://stackoverflow.com/a/40069656/1729555
+       */
+      IfStatement(__node) {
+        current_function.complexity += 1;
+      },
+      WhileStatement(__node) {
+        current_function.complexity += 1;
+      },
+      ForStatement(__node) {
+        current_function.complexity += 1;
+      },
+      DoWhileStatement(__node) {
+        current_function.complexity += 1;
+      },
+      InlineAssemblyStatement(__node) {
+        current_function.complexity += 3;
+      },
+      AssemblyIf(__node) {
+        current_function.complexity += 2;
+      },
+      SubAssembly(__node) {
+        current_function.complexity += 2;
+      },
+      AssemblyFor(__node) {
+        current_function.complexity += 2;
+      },
+      AssemblyCase(__node) {
+        current_function.complexity += 1;
+      },
+      Conditional(__node) {
+        current_function.complexity += 1;
+      },
+      AssemblyCall(__node) {
+        switch (__node.functionName) {
+          case 'call':
+          case 'delegatecall':
+          case 'staticcall':
+          case 'callcode':
+            current_function.complexity += 2;
+            current_function.calls.push({
+              //track asm calls
+              name: __node.functionName,
+              //contract_name: current_contract,
+              type: 'AssemblyCall',
+              callType: 'external',
+              declaration: {
+                type: 'Custom',
+                typeName: {
+                  namePath: 'assembly',
+                },
+                loc: __node.loc,
+              },
+              _node: __node,
             });
+
+            break;
+          default:
+            current_function.complexity += 1;
+            break;
         }
+      },
+      FunctionCall(__node) {
+        current_function.complexity += 2;
 
-        /**** body declarations */
-        parser.visit(_node, {
-            VariableDeclaration(__node) {
-                current_function.declarations[__node.name] = __node;
-            },
-            /** 
-             * subjective complexity - nr. of branching instructions 
-             *   https://stackoverflow.com/a/40069656/1729555
-            */
-            IfStatement(__node) { current_function.complexity += 1; },
-            WhileStatement(__node) { current_function.complexity += 1; },
-            ForStatement(__node) { current_function.complexity += 1; },
-            DoWhileStatement(__node) { current_function.complexity += 1; },
-            InlineAssemblyStatement(__node) { current_function.complexity += 3; },
-            AssemblyIf(__node) { current_function.complexity += 2; },
-            SubAssembly(__node) { current_function.complexity += 2; },
-            AssemblyFor(__node) { current_function.complexity += 2; },
-            AssemblyCase(__node) { current_function.complexity += 1; },
-            Conditional(__node) { current_function.complexity += 1; },
-            AssemblyCall(__node) {
+        var current_funccall = {
+          name: null,
+          //contract_name: current_contract,
+          type: null,
+          callType: null,
+          declaration: null,
+          _node: __node,
+        };
 
-                switch (__node.functionName) {
-                    case "call":
-                    case "delegatecall":
-                    case "staticcall":
-                    case "callcode":
-                        current_function.complexity += 2;
-                        current_function.calls.push({ //track asm calls
-                            name: __node.functionName,
-                            //contract_name: current_contract,
-                            type: "AssemblyCall",
-                            callType: "external",
-                            declaration: {
-                                type: "Custom",
-                                typeName: {
-                                    namePath: "assembly"
-                                },
-                                loc: __node.loc,
-                            },
-                            _node: __node,
-                        });
+        current_function.calls.push(current_funccall);
+        const expr = __node.expression;
 
-                        break;
-                    default:
-                        current_function.complexity += 1;
-                        break;
-                }
-            },
-            FunctionCall(__node) {
-                current_function.complexity += 2;
+        if (parserHelpers.isRegularFunctionCall(__node)) {
+          current_funccall.name = expr.name;
+          current_funccall.type = 'regular';
 
-                var current_funccall = {
-                    name: null,
-                    //contract_name: current_contract,
-                    type: null,
-                    callType: null,
-                    declaration: null,
-                    _node: __node,
-                };
+          //not external
+        } else if (parserHelpers.isMemberAccessOfNameValueExpression(__node)) {
+          // contract.method{value: 1}();  -- is always external
+          current_funccall.type = 'NameValueCall';
+          current_funccall.callType = 'external';
+          current_funccall.name =
+            current_funccall.name || __node.expression.expression.memberName;
+          current_funccall.declaration = {
+            type: 'Identifier',
+            typeName: undefined,
+            loc: __node.loc,
+          };
+        } else if (parserHelpers.isMemberAccess(__node)) {
+          current_funccall.name = expr.memberName;
+          current_funccall.type = 'memberAccess';
 
-                current_function.calls.push(current_funccall);
-                const expr = __node.expression;
+          if (expr.expression.hasOwnProperty('name')) {
+            // variable.send() - check if variable is of userdefinedtype or address, or array of address
 
-                if (parserHelpers.isRegularFunctionCall(__node)) {
-                    current_funccall.name = expr.name;
-                    current_funccall.type = "regular";
+            //1) could be a local declaration (or statevar)
+            let declaration = current_function._findScopedDeclaration(
+              expr.expression.name
+            );
+            if (
+              declaration &&
+              (parserHelpers.isAddressDeclaration(declaration) ||
+                parserHelpers.isUserDefinedDeclaration(declaration))
+            ) {
+              //statevar.send()
 
-                    //not external
+              if (declaration.typeName.namePath) {
+                let functionImplementationFound = false;
 
-                } else if (parserHelpers.isMemberAccessOfNameValueExpression(__node)) {
-                    // contract.method{value: 1}();  -- is always external
-                    current_funccall.type = "NameValueCall";
-                    current_funccall.callType = "external";
-                    current_funccall.name = current_funccall.name || __node.expression.expression.memberName;
-                    current_funccall.declaration = {
-                        type: "Identifier",
-                        typeName: undefined,
-                        loc: __node.loc,
-                    };
+                let fcandidates = [
+                  declaration.typeName.namePath, //complete typename
+                  declaration.typeName.namePath.split('.', 1)[0], //typename split
+                  ...current_contract
+                    ._existsUsingForDeclaration(declaration.typeName.namePath)
+                    .map((uf) => uf.libraryName), //all usingFors for typename
+                ];
 
-                } else if (parserHelpers.isMemberAccess(__node)) {
-                    current_funccall.name = expr.memberName;
-                    current_funccall.type = "memberAccess";
-
-                    if (expr.expression.hasOwnProperty('name')) {
-                        // variable.send() - check if variable is of userdefinedtype or address, or array of address
-
-                        //1) could be a local declaration (or statevar)
-                        let declaration = current_function._findScopedDeclaration(expr.expression.name);
-                        if (declaration && (parserHelpers.isAddressDeclaration(declaration) || parserHelpers.isUserDefinedDeclaration(declaration))) {
-                            //statevar.send()
-                            
-    
-                            if (declaration.typeName.namePath) {
-                                
-                                let functionImplementationFound = false;
-
-                                let fcandidates = [
-                                    declaration.typeName.namePath, //complete typename
-                                    declaration.typeName.namePath.split(".", 1)[0], //typename split
-                                    ...current_contract._existsUsingForDeclaration(declaration.typeName.namePath).map(uf => uf.libraryName) //all usingFors for typename
-                                ];
-
-                                for(let typename of new Set(fcandidates)){
-                                
-                                    //check if typename is a LIBRARY contract known to the system;
-                                    let found = current_contract._parent.workspace.findSync(su => su.contracts.hasOwnProperty(typename) && su.contracts[typename]._node.kind == "library");
-                                    if (found.length){
-                                        // but we have found a LIBRARY contract.
-                                        // check if the contract exports our function. --> likely, not an extcall ELSE extcall
-                                        functionImplementationFound = !!(found[0][typename] && found[0][typename].name && found[0][typename].names[current_funccall.name]);
-                                        if(functionImplementationFound){
-                                            break;
-                                        }
-                                    }
-                                }
-
-                                if(!functionImplementationFound){
-                                    //assume external call
-                                    current_funccall.type = "memberAccessOfVar";
-                                    current_funccall.callType = "external";  //likely external. can still be internal but we havent parsed the lib yet.
-                                    current_funccall.declaration = declaration;
-                                    current_funccall._helper = { contract: current_contract } // add a hint abt the current contract for 2nd pass
-
-                                } else {
-                                    current_funccall.type = undefined;
-                                    current_funccall.callType = undefined; //internal?
-                                    current_funccall.declaration = declaration;
-                                }
-                            }
-                            
-                            //@todo - existsUsingForDeclaration needs to find actual lib that implements it.
-                            //@todo - this can still be an internal call. check if target function is internal. do nothing in this case.
-                            //@todo - if target is a library and has a method with this name -> do nothing
-                        } else if (!declaration) {
-                            // potentially inherited.function(call)
-                            const is_library = !!current_contract._parent.workspace.findSync(su => su.contracts.hasOwnProperty(expr.expression.name) && su.contracts[expr.expression.name]._node.kind == "library").length;
-                            if (is_library) {
-                                // true negative: it is a library call, ignore
-                            } else {
-                                // might still be a libcall; need to refine in 2nd pass
-                                current_funccall.type = "memberAccessOfUnknownIdentifier";
-                                current_funccall.callType = "inconclusive";
-                                current_funccall.declaration = declaration; //resolve for node.expression.expression.name later
-                                current_funccall._helper = { contract: current_contract };
-                            }
-
-                        }
-                        //2) could be a contract type
-
-                        // checking if it is a member of `address` and pass along it's contents
-                    } else if (parserHelpers.isMemberAccessOfAddress(__node)) {
-                        // address(addr).send()
-                        current_funccall.type = "memberAccessOfAddress";
-                        current_funccall.callType = "external";
-                        current_funccall.declaration = __node.expression.expression.expression;
-
-                        // checking if it is a typecasting to a user-defined contract type
-                    } else if (parserHelpers.isAContractTypecast(__node)) {
-                        // Test(address).send(2);
-
-                        let ident = getExpressionIdentifier(__node);
-
-                        let target_contracts = current_contract._parent.contracts[ident.name];
-                        if (target_contracts) {
-                            target_contracts = [target_contracts];
-                        } else {
-                            target_contracts = current_contract._parent.workspace.findSync(su => su.contracts[ident.name] && su.contracts[ident.name]._node.kind != "library").map(su => su.contracts[ident.name]); //ignore libs
-                        }
-
-                        if (target_contracts && target_contracts.some(m => m.functions.find(f => f.name != __node.expression.memberName || (f.name != __node.expression.memberName && ["public", "external"].includes(f._node.visibility))))) {
-                            // its a contract, but method is not defined OR method is defined and public/external
-                            current_funccall.type = "contractTypecast";
-                            current_funccall.callType = "external";
-                            current_funccall.declaration = __node.expression.expression.expression;
-                        } else {
-                            current_funccall.type = "contractTypecastAnonymous";
-                            current_funccall.callType = "external";
-                            current_funccall.declaration = __node.expression.expression.expression;
-                        }
-
-                    } else if (parserHelpers.isMemberAccessOfArrayOrMapping(__node)) {
-                        //address[] addresses;  addresses[i].send();
-                        //check type of array
-                        let declaration;
-                        let base = __node.expression.expression.base;
-                        if (base && base.type == "Identifier") {
-                            declaration = current_function._findScopedDeclaration(base.name);
-                        }
-
-                        if (declaration) {
-                            if (parserHelpers.isAddressArrayDeclaration(declaration) || parserHelpers.isUserDefinedArrayDeclaration(declaration)) {
-                                //statevar.send()
-                                current_funccall.type = "memberAccessOfArrayVar";
-                                current_funccall.callType = "external";
-                                current_funccall.declaration = declaration;
-                            }
-                            else if (parserHelpers.isAddressMappingDeclaration(declaration)) {
-                                current_funccall.type = "memberAccessOfAddressMappingVarValue";
-                                current_funccall.callType = "external";
-                                current_funccall.declaration = declaration;
-                            }
-                            else if (parserHelpers.isUserDefinedMappingDeclaration(declaration)) {
-                                // could still be a lib. exclude libs
-
-                                //known non library contract?
-                                let typename = declaration.typeName.valueType.namePath;
-                                if (typename) {
-                                    typename = typename.split(".", 1)[0]; //get first typename
-
-
-                                    let knownContract = current_contract._parent.workspace.findSync(su => su.contracts.hasOwnProperty(typename) && su.contracts[typename]._node.kind != "library"); //ignore libs
-                                    if (knownContract.length) {
-                                        current_funccall.type = "memberAccessOfUserDefinedMappingVarValue";
-                                        current_funccall.callType = "external";
-                                        current_funccall.declaration = declaration;
-                                    }
-                                }
-                            }
-                        }
-                    } else if (parserHelpers.isMemberAccessOfGlobalEvmVar(__node)) {
-                        current_funccall.type = "memberAccessOfGlobalEvmVar";
-                        current_funccall.callType = "external";
-                        current_funccall.declaration = {
-                            type: "Identifier",
-                            name: `${__node.expression.expression.expression.name}.${__node.expression.expression.memberName}`,
-                            typeName: { namePath: "global" },
-                            loc: __node.loc,
-                        };
-
-                    } else if (parserHelpers.isMemberAccessOfStruct(__node)) {
-                        //struct[1].item.send(2)
-                        console.warn("Struct member external call detection not yet implemented");
-                        //need to recurse to find the "Identifier", fetch the declaration, resolve the type and check if Address or UserDefined.
-
-                    } else {
-                        //
-                        //current_funccall.debug = __node.expression;
+                for (let typename of new Set(fcandidates)) {
+                  //check if typename is a LIBRARY contract known to the system;
+                  let found = current_contract._parent.workspace.findSync(
+                    (su) =>
+                      su.contracts.hasOwnProperty(typename) &&
+                      su.contracts[typename]._node.kind == 'library'
+                  );
+                  if (found.length) {
+                    // but we have found a LIBRARY contract.
+                    // check if the contract exports our function. --> likely, not an extcall ELSE extcall
+                    functionImplementationFound = !!(
+                      found[0][typename] &&
+                      found[0][typename].name &&
+                      found[0][typename].names[current_funccall.name]
+                    );
+                    if (functionImplementationFound) {
+                      break;
                     }
-                } else {
-                    /** stuff that ends up here is very likely not relevant for us. */
-                    /** maybe an event? */
+                  }
+                }
 
-                    /* skip this check as we dont have a valid case for landing here */
-                    /*
+                if (!functionImplementationFound) {
+                  //assume external call
+                  current_funccall.type = 'memberAccessOfVar';
+                  current_funccall.callType = 'external'; //likely external. can still be internal but we havent parsed the lib yet.
+                  current_funccall.declaration = declaration;
+                  current_funccall._helper = { contract: current_contract }; // add a hint abt the current contract for 2nd pass
+                } else {
+                  current_funccall.type = undefined;
+                  current_funccall.callType = undefined; //internal?
+                  current_funccall.declaration = declaration;
+                }
+              }
+
+              //@todo - existsUsingForDeclaration needs to find actual lib that implements it.
+              //@todo - this can still be an internal call. check if target function is internal. do nothing in this case.
+              //@todo - if target is a library and has a method with this name -> do nothing
+            } else if (!declaration) {
+              // potentially inherited.function(call)
+              const is_library = !!current_contract._parent.workspace.findSync(
+                (su) =>
+                  su.contracts.hasOwnProperty(expr.expression.name) &&
+                  su.contracts[expr.expression.name]._node.kind == 'library'
+              ).length;
+              if (is_library) {
+                // true negative: it is a library call, ignore
+              } else {
+                // might still be a libcall; need to refine in 2nd pass
+                current_funccall.type = 'memberAccessOfUnknownIdentifier';
+                current_funccall.callType = 'inconclusive';
+                current_funccall.declaration = declaration; //resolve for node.expression.expression.name later
+                current_funccall._helper = { contract: current_contract };
+              }
+            }
+            //2) could be a contract type
+
+            // checking if it is a member of `address` and pass along it's contents
+          } else if (parserHelpers.isMemberAccessOfAddress(__node)) {
+            // address(addr).send()
+            current_funccall.type = 'memberAccessOfAddress';
+            current_funccall.callType = 'external';
+            current_funccall.declaration =
+              __node.expression.expression.expression;
+
+            // checking if it is a typecasting to a user-defined contract type
+          } else if (parserHelpers.isAContractTypecast(__node)) {
+            // Test(address).send(2);
+
+            let ident = getExpressionIdentifier(__node);
+
+            let target_contracts =
+              current_contract._parent.contracts[ident.name];
+            if (target_contracts) {
+              target_contracts = [target_contracts];
+            } else {
+              target_contracts = current_contract._parent.workspace
+                .findSync(
+                  (su) =>
+                    su.contracts[ident.name] &&
+                    su.contracts[ident.name]._node.kind != 'library'
+                )
+                .map((su) => su.contracts[ident.name]); //ignore libs
+            }
+
+            if (
+              target_contracts &&
+              target_contracts.some((m) =>
+                m.functions.find(
+                  (f) =>
+                    f.name != __node.expression.memberName ||
+                    (f.name != __node.expression.memberName &&
+                      ['public', 'external'].includes(f._node.visibility))
+                )
+              )
+            ) {
+              // its a contract, but method is not defined OR method is defined and public/external
+              current_funccall.type = 'contractTypecast';
+              current_funccall.callType = 'external';
+              current_funccall.declaration =
+                __node.expression.expression.expression;
+            } else {
+              current_funccall.type = 'contractTypecastAnonymous';
+              current_funccall.callType = 'external';
+              current_funccall.declaration =
+                __node.expression.expression.expression;
+            }
+          } else if (parserHelpers.isMemberAccessOfArrayOrMapping(__node)) {
+            //address[] addresses;  addresses[i].send();
+            //check type of array
+            let declaration;
+            let base = __node.expression.expression.base;
+            if (base && base.type == 'Identifier') {
+              declaration = current_function._findScopedDeclaration(base.name);
+            }
+
+            if (declaration) {
+              if (
+                parserHelpers.isAddressArrayDeclaration(declaration) ||
+                parserHelpers.isUserDefinedArrayDeclaration(declaration)
+              ) {
+                //statevar.send()
+                current_funccall.type = 'memberAccessOfArrayVar';
+                current_funccall.callType = 'external';
+                current_funccall.declaration = declaration;
+              } else if (
+                parserHelpers.isAddressMappingDeclaration(declaration)
+              ) {
+                current_funccall.type = 'memberAccessOfAddressMappingVarValue';
+                current_funccall.callType = 'external';
+                current_funccall.declaration = declaration;
+              } else if (
+                parserHelpers.isUserDefinedMappingDeclaration(declaration)
+              ) {
+                // could still be a lib. exclude libs
+
+                //known non library contract?
+                let typename = declaration.typeName.valueType.namePath;
+                if (typename) {
+                  typename = typename.split('.', 1)[0]; //get first typename
+
+                  let knownContract =
+                    current_contract._parent.workspace.findSync(
+                      (su) =>
+                        su.contracts.hasOwnProperty(typename) &&
+                        su.contracts[typename]._node.kind != 'library'
+                    ); //ignore libs
+                  if (knownContract.length) {
+                    current_funccall.type =
+                      'memberAccessOfUserDefinedMappingVarValue';
+                    current_funccall.callType = 'external';
+                    current_funccall.declaration = declaration;
+                  }
+                }
+              }
+            }
+          } else if (parserHelpers.isMemberAccessOfGlobalEvmVar(__node)) {
+            current_funccall.type = 'memberAccessOfGlobalEvmVar';
+            current_funccall.callType = 'external';
+            current_funccall.declaration = {
+              type: 'Identifier',
+              name: `${__node.expression.expression.expression.name}.${__node.expression.expression.memberName}`,
+              typeName: { namePath: 'global' },
+              loc: __node.loc,
+            };
+          } else if (parserHelpers.isMemberAccessOfStruct(__node)) {
+            //struct[1].item.send(2)
+            console.warn(
+              'Struct member external call detection not yet implemented'
+            );
+            //need to recurse to find the "Identifier", fetch the declaration, resolve the type and check if Address or UserDefined.
+          } else {
+            //
+            //current_funccall.debug = __node.expression;
+          }
+        } else {
+          /** stuff that ends up here is very likely not relevant for us. */
+          /** maybe an event? */
+          /* skip this check as we dont have a valid case for landing here */
+          /*
                     if (current_contract.events.some(e => e.name == __node.expression.name)){
                         return; // emit Event()
                     }
                     */
-                    /** ignore Contract TypeCast: e.g. Test(address)*/
-                }
-                if (current_funccall.callType == null) {
-                    //console.log(current_funccall);
-                }
-            },
-            AssemblyFunctionDefinition(__node) {
-                current_function.assemblyFunctions[__node.name] = __node;
-            }
-            // ignore throw, require, etc. for now
-        });
-
-        /**** all identifier */
-        /**** body declarations */
-        parser.visit(_node.body, {
-            //resolve scope
-            // check if defined in 
-            //
-            //
-            Identifier(__node) {
-                if (!current_function) {
-                    return;
-                }
-                let ident = __node;
-                ident.extra = {
-                    inFunction: current_function,
-                    scope: undefined,
-                    declaration: undefined
-                }
-
-                // find declaration; narrow scope first
-                if (current_function.declarations[ident.name]) {
-                    // local declaration; can be ARGS, RETURNS or BODY
-                    if (current_function.arguments[ident.name]) {
-                        ident.extra.scope = "argument";
-                        ident.extra.declaration = current_function.arguments[ident.name];
-                    } else if (current_function.returns[ident.name]) {
-                        ident.extra.scope = "returns";
-                        ident.extra.declaration = current_function.returns[ident.name];
-                    } else {
-                        ident.extra.scope = "body";
-                        ident.extra.declaration = current_function.declarations[ident.name];
-                    }
-
-                    if (ident.extra.declaration.storageLocation == "storage") {
-                        ident.extra.scope = "storageRef"; // is a storage reference; may be treated as statevar
-                    }
-
-                } else if (current_contract.stateVars[ident.name]) {
-                    // statevar
-                    ident.extra.scope = "stateVar";
-                    ident.extra.declaration = current_contract.stateVars[ident.name];
-                } else if (current_contract.inherited_names[ident.name] && current_contract.inherited_names[ident.name] != current_contract) {
-                    // inherited
-                    // inaccurate first check. needs to be resolved after parsing all files
-                    ident.extra.scope = "inheritedName";
-                    ident.extra.declaration = current_contract.inherited_names[ident.name];
-                } else {
-                    // unclear scope, likely inherited
-                    // normal identifier or inconclusive
-                }
-
-                current_function.identifiers.push(__node);
-            },
-            AssemblyCall(__node) {
-                if (!current_function) {
-                    return;
-                }
-                __node.extra = {
-                    inFunction: current_function
-                }
-                current_function.identifiers.push(__node);
-            }
-        });
-
-        parser.visit(_node.modifiers, {
-            ModifierInvocation: function (__node) {
-                current_function.modifiers[__node.name] = __node;
-
-                //subparse arguments as identifiers
-                parser.visit(__node.arguments, {
-                    Identifier: function(nodeModArgIdent){
-                        if (!current_function) {
-                            return;
-                        }
-                        let ident = nodeModArgIdent;
-                        ident.extra = {
-                            inFunction: current_function,
-                            scope: "super",
-                            declaration: current_function.arguments[ident.name]
-                        }
-                        current_function.identifiers.push(ident);
-                    }
-                });
-            }
-        });
-    }
-
-    _findScopedDeclaration(name) {
-        //check if name is in local functions scope (declaration), arguments, returns, or statevar
-        if (this.declarations[name]) {
-            return this.declarations[name];
+          /** ignore Contract TypeCast: e.g. Test(address)*/
         }
-        /*
+        if (current_funccall.callType == null) {
+          //console.log(current_funccall);
+        }
+      },
+      AssemblyFunctionDefinition(__node) {
+        current_function.assemblyFunctions[__node.name] = __node;
+      },
+      // ignore throw, require, etc. for now
+    });
+
+    /**** all identifier */
+    /**** body declarations */
+    parser.visit(_node.body, {
+      //resolve scope
+      // check if defined in
+      //
+      //
+      Identifier(__node) {
+        if (!current_function) {
+          return;
+        }
+        let ident = __node;
+        ident.extra = {
+          inFunction: current_function,
+          scope: undefined,
+          declaration: undefined,
+        };
+
+        // find declaration; narrow scope first
+        if (current_function.declarations[ident.name]) {
+          // local declaration; can be ARGS, RETURNS or BODY
+          if (current_function.arguments[ident.name]) {
+            ident.extra.scope = 'argument';
+            ident.extra.declaration = current_function.arguments[ident.name];
+          } else if (current_function.returns[ident.name]) {
+            ident.extra.scope = 'returns';
+            ident.extra.declaration = current_function.returns[ident.name];
+          } else {
+            ident.extra.scope = 'body';
+            ident.extra.declaration = current_function.declarations[ident.name];
+          }
+
+          if (ident.extra.declaration.storageLocation == 'storage') {
+            ident.extra.scope = 'storageRef'; // is a storage reference; may be treated as statevar
+          }
+        } else if (current_contract.stateVars[ident.name]) {
+          // statevar
+          ident.extra.scope = 'stateVar';
+          ident.extra.declaration = current_contract.stateVars[ident.name];
+        } else if (
+          current_contract.inherited_names[ident.name] &&
+          current_contract.inherited_names[ident.name] != current_contract
+        ) {
+          // inherited
+          // inaccurate first check. needs to be resolved after parsing all files
+          ident.extra.scope = 'inheritedName';
+          ident.extra.declaration =
+            current_contract.inherited_names[ident.name];
+        } else {
+          // unclear scope, likely inherited
+          // normal identifier or inconclusive
+        }
+
+        current_function.identifiers.push(__node);
+      },
+      AssemblyCall(__node) {
+        if (!current_function) {
+          return;
+        }
+        __node.extra = {
+          inFunction: current_function,
+        };
+        current_function.identifiers.push(__node);
+      },
+    });
+
+    parser.visit(_node.modifiers, {
+      ModifierInvocation: function (__node) {
+        current_function.modifiers[__node.name] = __node;
+
+        //subparse arguments as identifiers
+        parser.visit(__node.arguments, {
+          Identifier: function (nodeModArgIdent) {
+            if (!current_function) {
+              return;
+            }
+            let ident = nodeModArgIdent;
+            ident.extra = {
+              inFunction: current_function,
+              scope: 'super',
+              declaration: current_function.arguments[ident.name],
+            };
+            current_function.identifiers.push(ident);
+          },
+        });
+      },
+    });
+  }
+
+  _findScopedDeclaration(name) {
+    //check if name is in local functions scope (declaration), arguments, returns, or statevar
+    if (this.declarations[name]) {
+      return this.declarations[name];
+    }
+    /*
         if(this.arguments[name]){
             return this.arguments[name];
         }
@@ -1184,26 +1411,65 @@ class FunctionDef {
             return this.returns[name];
         }
         */
-        if (this.parent.stateVars[name]) {
-            return this.parent.stateVars[name];
-        }
+    if (this.parent.stateVars[name]) {
+      return this.parent.stateVars[name];
+    }
 
-        /* // included in svar
+    /* // included in svar
         if(this.parent.mappings[name]){
             return this.parent.mappings[name];
         }
         */
 
-        return undefined;
-    }
+    return undefined;
+  }
 
-    getExternalCalls(criteria) {
+  getExternalCalls(criteria) {
+    return this.calls.filter((c) =>
+      criteria ? criteria(c) : c.callType == 'external'
+    );
+  }
 
-        return this.calls.filter(c => criteria ? criteria(c) : c.callType == "external");
+  getFunctionSignature() {
+    //should check if structs in the contract have been resolved first!
+    const contract = this.parent;
+    if (!contract) {
+      throw new Error('Missing contract for the current function');
     }
+    if (!contract.resolvedInheritance) {
+      //resolve inherited structs before
+      throw new Error(
+        'Please resolve inheritance for this source unit before computing function signatures.'
+      );
+    }
+    let funcname = this.name;
+
+    // let argsItem =
+    //   item.parameters.type === 'ParameterList'
+    //     ? item.parameters.parameters
+    //     : item.parameters;
+    let args = Object.values(this.arguments).map((o) =>
+      canonicalizeEvmType(
+        getCanonicalizedArgumentFromAstNode(o, this._node, contract)
+      )
+    );
+
+    let fnsig = `${funcname}(${args.join(',')})`;
+    let sighash = createKeccakHash('keccak256')
+      .update(fnsig)
+      .digest('hex')
+      .toString('hex')
+      .slice(0, 8);
+
+    return {
+      name: funcname,
+      signature: fnsig,
+      sighash: sighash,
+    };
+  }
 }
 
 module.exports = {
-    Workspace,
-    SourceUnit
+  Workspace,
+  SourceUnit,
 };

--- a/src/parser/solidity.js
+++ b/src/parser/solidity.js
@@ -237,10 +237,11 @@ class Workspace {
     }
 
     if (subcontract._node.kind === 'interface') {
-      //only consider structs
+      //only consider structs and enums
       for (let _var in subcontract.structs) {
         contract.inherited_names[_var] = subcontract;
         contract.inherited_structs[_var] = subcontract.structs[_var];
+        contract.inherited_enums[_var] = subcontract.enums[_var];
       }
       return; //skip other inherited names from interfaces
     }


### PR DESCRIPTION
This PR makes the following changes:
- It makes several improvement to the caching logic to optimize the cache from growing indefinitely and optimize the memory footprint and the overall performances of the extension. 
- It adds the logic to resolve identifiers inherited from other contracts, and imported source units (structs and enums). 
- It adds the logic needed to compute function signatures from a function definition node in the AST.  

To enforce a consistent style, the source were formatted with prettier. Also note that this update might introduce breaking changes with `vscode-solidity-auditor` (PR on the way)